### PR TITLE
Feature - RxResultBuilder

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -16,8 +16,8 @@ jobs:
       # environment.
       matrix:
         device:
-        - "iPhone 8 (13.3)"
-        - "iPhone 11 Pro Max (13.3)"
+        - "iPhone 8 (13.6)"
+        - "iPhone 11 Pro Max (13.6)"
       # When set to true, GitHub cancels all in-progress jobs if any        
       # matrix job fails.
       fail-fast: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Updated README file
 * Updated example
 * Updated Unit Tests
+* Updated Workflow configuration
 
 ## [0.1.2] - March 19, 2020
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.0.0] - August 7, 2020
+
+* Added RxResultBuilder
+* Updated README file
+* Updated example
+* Updated Unit Tests
+
 ## [0.1.2] - March 19, 2020
 
 * Update package dependencies

--- a/README.md
+++ b/README.md
@@ -37,6 +37,44 @@ RxBlocBuilder<NewsBlocType, List<News>>(
 )
 ```
 
+**RxResultBuilder** is a Flutter widget which requires a `state` function, a set of callbacks `buildSuccess`, `buildError` and `buildLoading`, and an optional `RxBloc`. `RxResultBuilder` is similar to `RxBlocBuilder`, however it is meant as an easier way to handle `Result` states.
+
+* The `buildSuccess`, `buildError` and `buildLoading` functions will potentially be called many times and should be [pure functions](https://en.wikipedia.org/wiki/Pure_function) that return a widget in response to the state.
+* The `state` function determines which exact state of the bloc will be used. 
+* If the `bloc` parameter is omitted, `RxBlocBuilder` will automatically perform a lookup using `RxBlocProvider` and the current `BuildContext`. 
+
+See `RxBlocListener` if you want to "do" anything in response to state changes such as navigation, showing a dialog, etc...
+
+
+```dart
+/// At the first placeholder define what bloc you need, at the second define the type of the [Result] state you want to listen to.
+/// It needs to match the type of the stream in the state function below.
+RxBlocBuilder<NewsBlocType, List<News>>( 
+/// Determine which exact state of the bloc will be used for building the widget below. 
+/// In this case the stream [bloc.states.news] should have a type of [Stream<Result<List<News>>>]
+  state: (bloc) => bloc.states.news, 
+  buildSuccess: (context, data, bloc) {
+    ///here return a widget based on the data from the [Result]
+  },
+  buildLoading: (context, bloc) {
+    ///here return a widget showing that we are waiting for the data, e.g. loading indicator
+  },
+  buildError: (context, error, bloc) {
+    ///here return a widget showing what went wrong 
+  },
+)
+```
+
+Only specify the bloc if you wish to provide a bloc that will be scoped to a single widget and isn't accessible via a parent `RxBlocProvider` and the current `BuildContext`.
+
+```dart
+RxBlocBuilder<NewsBlocType, List<News>>(
+  bloc: blocA, // provide the local bloc instance
+  state: (bloc) => bloc.states.news, // Determine which exact state of the bloc will be used for building the widget below.
+  ...
+)
+```
+
 **RxBlocProvider** is a Flutter widget which provides a bloc to its children via `RxBlocProvider.of<T>(context)`. It is used as a dependency injection (DI) widget so that a single instance of a bloc can be provided to multiple widgets within a subtree.
 
 In most cases, `RxBlocProvider` should be used to create new `blocs` which will be made available to the rest of the subtree. In this case, since `RxBlocProvider` is responsible for creating the bloc, it will automatically handle closing the bloc.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ RxBlocBuilder<NewsBlocType, List<News>>(
 
 * The `buildSuccess`, `buildError` and `buildLoading` functions will potentially be called many times and should be [pure functions](https://en.wikipedia.org/wiki/Pure_function) that return a widget in response to the state.
 * The `state` function determines which exact state of the bloc will be used. 
-* If the `bloc` parameter is omitted, `RxBlocBuilder` will automatically perform a lookup using `RxBlocProvider` and the current `BuildContext`. 
+* If the `bloc` parameter is omitted, `RxResultBuilder` will automatically perform a lookup using `RxBlocProvider` and the current `BuildContext`. 
 
 See `RxBlocListener` if you want to "do" anything in response to state changes such as navigation, showing a dialog, etc...
 
@@ -49,7 +49,7 @@ See `RxBlocListener` if you want to "do" anything in response to state changes s
 ```dart
 /// At the first placeholder define what bloc you need, at the second define the type of the [Result] state you want to listen to.
 /// It needs to match the type of the stream in the state function below.
-RxBlocBuilder<NewsBlocType, List<News>>( 
+RxResultBuilder<NewsBlocType, List<News>>( 
 /// Determine which exact state of the bloc will be used for building the widget below. 
 /// In this case the stream [bloc.states.news] should have a type of [Stream<Result<List<News>>>]
   state: (bloc) => bloc.states.news, 
@@ -68,7 +68,7 @@ RxBlocBuilder<NewsBlocType, List<News>>(
 Only specify the bloc if you wish to provide a bloc that will be scoped to a single widget and isn't accessible via a parent `RxBlocProvider` and the current `BuildContext`.
 
 ```dart
-RxBlocBuilder<NewsBlocType, List<News>>(
+RxResultBuilder<NewsBlocType, List<News>>(
   bloc: blocA, // provide the local bloc instance
   state: (bloc) => bloc.states.news, // Determine which exact state of the bloc will be used for building the widget below.
   ...

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This package is built to work with [rx_bloc](https://github.com/Prime-Holding/Rx
 
 * The `builder` function will potentially be called many times and should be a [pure function](https://en.wikipedia.org/wiki/Pure_function) that returns a widget in response to the state.
 * The `state` function determines which exact state of the bloc will be used. 
-* If the `bloc` parameter is omitted, `RxBlocBuilder` will automatically perform a lookup using `RxBlocProvider` and the current `BuildContext`. 
+* If the `bloc` parameter is omitted, `RxBlocBuilder` will automatically perform a lookup using `RxBlocProvider` and the current `BuildContext`.
 
 See `RxBlocListener` if you want to "do" anything in response to state changes such as navigation, showing a dialog, etc...
 
@@ -41,10 +41,7 @@ RxBlocBuilder<NewsBlocType, List<News>>(
 
 * The `buildSuccess`, `buildError` and `buildLoading` functions will potentially be called many times and should be [pure functions](https://en.wikipedia.org/wiki/Pure_function) that return a widget in response to the state.
 * The `state` function determines which exact state of the bloc will be used. 
-* If the `bloc` parameter is omitted, `RxResultBuilder` will automatically perform a lookup using `RxBlocProvider` and the current `BuildContext`. 
-
-See `RxBlocListener` if you want to "do" anything in response to state changes such as navigation, showing a dialog, etc...
-
+* If the `bloc` parameter is omitted, `RxResultBuilder` will automatically perform a lookup using `RxBlocProvider` and the current `BuildContext`.
 
 ```dart
 /// At the first placeholder define what bloc you need, at the second define the type of the [Result] state you want to listen to.

--- a/example/lib/bloc/details_bloc.dart
+++ b/example/lib/bloc/details_bloc.dart
@@ -11,7 +11,7 @@ abstract class DetailsBlocEvents {
 }
 
 abstract class DetailsBlocStates {
-  Stream<String> get details;
+  Stream<Result<String>> get details;
 
   @RxBlocIgnoreState()
   Stream<bool> get isLoading;
@@ -27,11 +27,10 @@ class DetailsBloc extends $DetailsBloc {
   DetailsBloc(this._detailsRepository);
 
   @override
-  Stream<String> _mapToDetailsState() => _$fetchEvent
+  Stream<Result<String>> _mapToDetailsState() => _$fetchEvent
       .startWith(null)
       .flatMap((_) => _detailsRepository.fetch().asResultStream())
-      .setResultStateHandler(this)
-      .whereSuccess();
+      .setResultStateHandler(this);
 
   @override
   Stream<String> get errors =>

--- a/example/lib/bloc/details_bloc.rxb.g.dart
+++ b/example/lib/bloc/details_bloc.rxb.g.dart
@@ -29,12 +29,12 @@ abstract class $DetailsBloc extends RxBlocBase
   ///region States
 
   ///region details
-  Stream<String> _detailsState;
+  Stream<Result<String>> _detailsState;
 
   @override
-  Stream<String> get details => _detailsState ??= _mapToDetailsState();
+  Stream<Result<String>> get details => _detailsState ??= _mapToDetailsState();
 
-  Stream<String> _mapToDetailsState();
+  Stream<Result<String>> _mapToDetailsState();
 
   ///endregion details
 

--- a/example/lib/widgets/details_widget.dart
+++ b/example/lib/widgets/details_widget.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_rx_bloc/provider/rx_bloc_builder.dart';
+import 'package:flutter_rx_bloc/provider/rx_result_builder.dart';
 
 import '../bloc/details_bloc.dart';
 
@@ -16,14 +17,14 @@ class DetailsWidget extends StatelessWidget {
           children: <Widget>[
             Expanded(
               child: Center(
-                child: RxBlocBuilder<DetailsBlocType, String>(
+                child: RxResultBuilder<DetailsBlocType, String>(
                   state: (bloc) => bloc.states.details,
-                  builder: (context, snapshot, bloc) => Text(
-                    snapshot.data ?? '',
-                    textAlign: TextAlign.center,
-                    style: TextStyle(fontSize: 26),
-                    key: ValueKey('reload_text'),
-                  ),
+                  buildSuccess: (context, data, bloc) =>
+                      _buildDetailsText(data ?? ''),
+                  buildLoading: (context, bloc) =>
+                      _buildDetailsText('Loading...'),
+                  buildError: (context, error, bloc) =>
+                      _buildDetailsText('Error: $error'),
                 ),
               ),
             ),
@@ -42,6 +43,13 @@ class DetailsWidget extends StatelessWidget {
       ),
     );
   }
+
+  Widget _buildDetailsText(String text) => Text(
+        text,
+        textAlign: TextAlign.center,
+        style: TextStyle(fontSize: 26),
+        key: ValueKey('reload_text'),
+      );
 }
 
 extension _IsLoading on AsyncSnapshot {

--- a/example/test/bloc_tests/details_bloc_test.dart
+++ b/example/test/bloc_tests/details_bloc_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
+import 'package:rx_bloc/model/result.dart';
 import 'package:rx_bloc_test/rx_bloc_test.dart';
 
 import '../../lib/bloc/details_bloc.dart';
@@ -19,13 +20,17 @@ void main() {
       });
     });
 
-    rxBlocTest<DetailsBloc, String>(
+    rxBlocTest<DetailsBloc, Result<String>>(
       'Fetching details',
       build: () async => DetailsBloc(mockRepo),
       state: (bloc) => bloc.states.details,
       act: (bloc) async => bloc.events.fetch(),
       wait: Duration(milliseconds: 60),
-      expect: ['Success'],
+      expect: [
+        Result<String>.loading(),
+        Result.success('Success'),
+        Result.success('Success'),
+      ],
     );
   });
 }

--- a/example/test/bloc_tests/details_bloc_test.dart
+++ b/example/test/bloc_tests/details_bloc_test.dart
@@ -20,13 +20,18 @@ void main() {
       });
     });
 
+    //The DetailsBloc starts by automatically fetching data from the Repo,
+    //therefore after we make another fetch request we expect to get two loading
+    //states and two success states
     rxBlocTest<DetailsBloc, Result<String>>(
       'Fetching details',
       build: () async => DetailsBloc(mockRepo),
       state: (bloc) => bloc.states.details,
       act: (bloc) async => bloc.events.fetch(),
       wait: Duration(milliseconds: 60),
+      skip: 0,
       expect: [
+        Result<String>.loading(),
         Result<String>.loading(),
         Result.success('Success'),
         Result.success('Success'),

--- a/lib/provider/rx_result_builder.dart
+++ b/lib/provider/rx_result_builder.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/widgets.dart';
+import 'package:rx_bloc/rx_bloc.dart';
+
+import 'rx_bloc_provider.dart';
+
+/// [RxResultBuilder] handles building a widget in response
+/// to new [Result] states
+///
+/// See also:
+///   * [RxBlocBuilder], which handles building the widget in response
+///     to new states
+///
+///   * [StreamBuilder], which delegates to an [AsyncWidgetBuilder] to build
+///     itself based on a snapshot from interacting with a [Stream].
+class RxResultBuilder<B extends RxBlocTypeBase, T> extends StatelessWidget {
+  /// The BLoC state based on which this widget rebuilds itself
+  final Stream<Result<T>> Function(B) state;
+
+  ///The [RxBloc] which provides the state for this widget
+  final B bloc;
+
+  /// Callback which is invoked when the [state] stream produces an event
+  /// which is [ResultSuccess]
+  final Widget Function(BuildContext, T, B) buildSuccess;
+
+  /// Callback which is invoked when the [state] stream produces an event
+  /// which is [ResultError]
+  ///
+  /// If the [AsyncSnapshot] of the stream has an [Exception]
+  /// this is called with that [Exception]
+  final Widget Function(BuildContext, String, B) buildError;
+
+  /// Callback which is invoked when the [state] stream produces an event
+  /// which is [ResultLoading]
+  ///
+  /// This is also called if a build is requested while still waiting for
+  /// the first event of the [state] stream
+  final Widget Function(BuildContext, B) buildLoading;
+
+  const RxResultBuilder({
+    @required this.state,
+    @required this.buildSuccess,
+    @required this.buildError,
+    @required this.buildLoading,
+    this.bloc,
+    Key key,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final block = this.bloc ?? RxBlocProvider.of<B>(context);
+
+    return StreamBuilder<Result<T>>(
+      stream: state(block),
+      builder: (buildContext, snapshot) {
+        final result = snapshot.connectionState == ConnectionState.active ||
+                snapshot.connectionState == ConnectionState.done
+            ? (snapshot.hasError ? Result.error(snapshot.error) : snapshot.data)
+            : Result.loading();
+
+        if (result is ResultSuccess<T>) {
+          return buildSuccess(buildContext, result.data, block);
+        } else if (result is ResultError<T>) {
+          return buildError(buildContext, result.error.toString(), block);
+        } else {
+          return buildLoading(context, block);
+        }
+      },
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_rx_bloc
 description: Set of Flutter Widgets that help implementing the BLoC design pattern. Built to be used with the rx_bloc package.
-version: 0.1.2
+version: 1.0.0
 repository: https://github.com/Prime-Holding/FlutterRxBloc
 issue_tracker: https://github.com/Prime-Holding/FlutterRxBloc/issues
 homepage: https://primeholding.com/


### PR DESCRIPTION
Created a widget which can better handle **`Result`** streams.

Changed the example to show off how it works. Since the `DetailsWidget` was already using two `RxBlocBuilders`, I decided one of them would work better as an `RxResultBuilder`, however if you do not like this I could easily add a separate example.

Also made some changes to the unit tests.